### PR TITLE
Bug fix in saveToJpeg when creating new Exif block.

### DIFF
--- a/src/libraries/qtopia/qexifimageheader.cpp
+++ b/src/libraries/qtopia/qexifimageheader.cpp
@@ -1031,7 +1031,6 @@ bool QExifImageHeader::saveToJpeg(QIODevice *device) const
             stream << quint16( 0xFFE1 ); //APP1
             stream << quint16( exif.size() + 2 );
             device->write( exif );
-            stream << quint16( 0xFFE0 ); // APP0
             stream << segmentId;
             stream << segmentLength;
             device->write( remainder );


### PR DESCRIPTION
Saving an Exif block in file that doesn't have one breaks the format.
Here's the fix.